### PR TITLE
FortnoxException error message in stacktrace

### DIFF
--- a/src/main/java/org/notima/api/fortnox/FortnoxException.java
+++ b/src/main/java/org/notima/api/fortnox/FortnoxException.java
@@ -66,5 +66,9 @@ public class FortnoxException extends Exception {
 		else
 			return (errorInformation.getError() + " : " + errorInformation.getMessage() + " : " + errorInformation.getCode());
 	}
+
+	public String getMessage() {
+		return this.toString();
+	}
 	
 }


### PR DESCRIPTION
Overriding `getMessage()` of `FortnoxException` in order to get more informative error messages. For example:

    org.notima.api.fortnox.FortnoxException: 1 : Ogiltig inloggning : 2004054
            at org.notima.api.fortnox.FortnoxClient3.getPreDefinedAccount(FortnoxClient3.java:1239) ~[?:?]
            ...
Instead of:

    org.notima.api.fortnox.FortnoxException: null
            at org.notima.api.fortnox.FortnoxClient3.getPreDefinedAccount(FortnoxClient3.java:1239) ~[?:?]