### PR TITLE
FortnoxClient3 always gets client id and secret from credentials provider

### DIFF
--- a/src/main/java/org/notima/api/fortnox/clients/FortnoxCredentials.java
+++ b/src/main/java/org/notima/api/fortnox/clients/FortnoxCredentials.java
@@ -6,6 +6,9 @@ public class FortnoxCredentials {
 
     private String orgNo;
 
+    private String clientId;
+    private String clientSecret;
+
     @SerializedName("authorization_code")
     private String authorizationCode;
 
@@ -33,6 +36,22 @@ public class FortnoxCredentials {
 
     public void setOrgNo(String orgNo) {
         this.orgNo = orgNo;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
     }
 
     public String getAuthorizationCode() {

--- a/src/test/java/org/notima/api/fortnox/junit/TestUtil.java
+++ b/src/test/java/org/notima/api/fortnox/junit/TestUtil.java
@@ -20,7 +20,7 @@ public class TestUtil {
 	 * @throws Exception 
 	 */
 	public static FortnoxClient3 getFortnoxClient() throws Exception {
-		FortnoxClient3 client = new FortnoxClient3("FortnoxClientList.xml", new FortnoxCredentialsProvider("") {
+		FortnoxClient3 client = new FortnoxClient3(new FortnoxCredentialsProvider("") {
 			URL file = Thread.currentThread().getContextClassLoader().getResource("FortnoxCredentials.json");
 			private Gson gson = new GsonBuilder().setPrettyPrinting().create();
 


### PR DESCRIPTION
Only one constructor for FortnoxClient3 exists (`FortnoxClient3(FortnoxCredentialsProvider credentialsProvider)`). 
`m_clientId` and `m_clientSecret` have been removed in favor of new variables in the credentials object